### PR TITLE
Feature/floating header

### DIFF
--- a/PanelViewController.xcodeproj/project.pbxproj
+++ b/PanelViewController.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		93A3C0A520190397009E1804 /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A3C0A420190397009E1804 /* ListViewController.swift */; };
 		93A3C0A7201906C9009E1804 /* PaneBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A3C0A6201906C9009E1804 /* PaneBehavior.swift */; };
 		93A3C0A920191653009E1804 /* DraggableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93A3C0A820191653009E1804 /* DraggableView.swift */; };
+		93D37FF52097797F00761908 /* ButtonContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D37FF42097797F00761908 /* ButtonContainerView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,6 +57,7 @@
 		93A3C0A420190397009E1804 /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
 		93A3C0A6201906C9009E1804 /* PaneBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneBehavior.swift; sourceTree = "<group>"; };
 		93A3C0A820191653009E1804 /* DraggableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggableView.swift; sourceTree = "<group>"; };
+		93D37FF42097797F00761908 /* ButtonContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonContainerView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,6 +113,7 @@
 			children = (
 				93A3C07D2018FD8C009E1804 /* AppDelegate.swift */,
 				93A3C0842018FD8C009E1804 /* Assets.xcassets */,
+				93D37FF42097797F00761908 /* ButtonContainerView.swift */,
 				9377B88420322D7500ADCF5D /* ContainerViewController.swift */,
 				9399F69F2048B1030047574B /* Framework source */,
 				93A3C0892018FD8C009E1804 /* Info.plist */,
@@ -256,6 +259,7 @@
 				93A3C09F2018FF30009E1804 /* UIViewController+Parenting.swift in Sources */,
 				93A3C0A7201906C9009E1804 /* PaneBehavior.swift in Sources */,
 				93A3C0A320190389009E1804 /* MapViewController.swift in Sources */,
+				93D37FF52097797F00761908 /* ButtonContainerView.swift in Sources */,
 				93A3C0A120190130009E1804 /* PanelViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/PanelViewController/Base.lproj/Main.storyboard
+++ b/PanelViewController/Base.lproj/Main.storyboard
@@ -41,8 +41,8 @@
                     </view>
                     <navigationItem key="navigationItem" id="VhN-8j-Zvp"/>
                     <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="string" keyPath="mainViewControllerStoryBoardID" value="MapViewController"/>
-                        <userDefinedRuntimeAttribute type="string" keyPath="panelViewControllerStoryBoardID" value="ListViewController"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="backViewControllerStoryBoardID" value="MapViewController"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="slidingViewControllerStoryBoardID" value="ListViewController"/>
                     </userDefinedRuntimeAttributes>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/PanelViewController/ButtonContainerView.swift
+++ b/PanelViewController/ButtonContainerView.swift
@@ -9,8 +9,6 @@
 import UIKit
 
 // This is an example of a view to be used by the PanelViewController's floatingHeaderView property.
-// PanelViewController will adjust the origin and width as it sees fit. It will preserve whatever height you set.
-
 final class ButtonContainerView: UIView {
     private let button = UIButton()
     var buttonAction: (() -> Void)?

--- a/PanelViewController/ButtonContainerView.swift
+++ b/PanelViewController/ButtonContainerView.swift
@@ -36,4 +36,13 @@ final class ButtonContainerView: UIView {
             buttonAction()
         }
     }
+    
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        if button.point(inside: convert(point, to: button), with: event) {
+            return true
+        }
+        
+        return false
+    }
+
 }

--- a/PanelViewController/ButtonContainerView.swift
+++ b/PanelViewController/ButtonContainerView.swift
@@ -1,0 +1,31 @@
+//
+//  ButtonContainerView.swift
+//  PanelViewController
+//
+//  Created by Kaden, Joshua on 4/30/18.
+//  Copyright © 2018 NYC DoITT. All rights reserved.
+//
+
+import UIKit
+
+final class ButtonContainerView: UIView {
+    private let button = UIButton()
+    
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
+        guard let _ = newWindow else { return }
+        
+        button.backgroundColor = .white
+        button.setTitle("Center", for: .normal)
+        button.setTitleColor(.black, for: .normal)
+        addSubview(button)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        
+        let buttonX = bounds.width - 100 - 8
+        let buttonFrame = CGRect(x: buttonX, y: 8, width: 100, height: 44)
+        button.frame = buttonFrame
+    }
+}

--- a/PanelViewController/ButtonContainerView.swift
+++ b/PanelViewController/ButtonContainerView.swift
@@ -10,11 +10,13 @@ import UIKit
 
 final class ButtonContainerView: UIView {
     private let button = UIButton()
+    var buttonAction: (() -> Void)?
     
     override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
         guard let _ = newWindow else { return }
         
+        button.addTarget(self, action: #selector(didTapButton(_:)), for: .touchUpInside)
         button.backgroundColor = .white
         button.setTitle("Center", for: .normal)
         button.setTitleColor(.black, for: .normal)
@@ -27,5 +29,11 @@ final class ButtonContainerView: UIView {
         let buttonX = bounds.width - 100 - 8
         let buttonFrame = CGRect(x: buttonX, y: 8, width: 100, height: 44)
         button.frame = buttonFrame
+    }
+    
+    @objc func didTapButton(_ sender: UIButton) {
+        if let buttonAction = buttonAction {
+            buttonAction()
+        }
     }
 }

--- a/PanelViewController/ButtonContainerView.swift
+++ b/PanelViewController/ButtonContainerView.swift
@@ -8,6 +8,9 @@
 
 import UIKit
 
+// This is an example of a view to be used by the PanelViewController's floatingHeaderView property.
+// PanelViewController will adjust the origin and width as it sees fit. It will preserve whatever height you set.
+
 final class ButtonContainerView: UIView {
     private let button = UIButton()
     var buttonAction: (() -> Void)?
@@ -38,6 +41,8 @@ final class ButtonContainerView: UIView {
     }
     
     override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        // This allows the button to be tapped. Every other touch is passed up the responder chain.
+        // In this way, the header view can be a "pass-through" view.
         if button.point(inside: convert(point, to: button), with: event) {
             return true
         }

--- a/PanelViewController/ContainerViewController.swift
+++ b/PanelViewController/ContainerViewController.swift
@@ -47,7 +47,7 @@ final class ContainerViewController: UIViewController {
     }
     
     @objc func didTapAnimateDown(_ sender: UIButton) {
-        let newState: PaneState
+        let newState: PanelState
         switch panelViewController.paneState {
         case .closed:
             return
@@ -64,7 +64,7 @@ final class ContainerViewController: UIViewController {
     }
     
     @objc func didTapAnimateUp(_ sender: UIButton) {
-        let newState: PaneState
+        let newState: PanelState
         switch panelViewController.paneState {
         case .closed:
             if panelViewController.showsMidState {

--- a/PanelViewController/Framework source/DraggableView.swift
+++ b/PanelViewController/Framework source/DraggableView.swift
@@ -73,7 +73,7 @@ class DraggableView: UIView {
                 return false
             }
         }
-        // The default path; return true.
-        return true
+        // The default path; return super's value.
+        return super.point(inside: point, with: event)
     }
 }

--- a/PanelViewController/Framework source/DraggableView.swift
+++ b/PanelViewController/Framework source/DraggableView.swift
@@ -16,6 +16,15 @@ protocol DraggableViewDelegate: class {
 class DraggableView: UIView {
     weak var delegate: DraggableViewDelegate?
     
+    var floatingHeaderView: UIView? {
+        didSet {
+            oldValue?.removeFromSuperview()
+            if let newValue = floatingHeaderView {
+                addSubview(newValue)
+            }
+        }
+    }
+    
     override func willMove(toWindow newWindow: UIWindow?) {
         super.willMove(toWindow: newWindow)
         guard let _ = newWindow else { return }
@@ -45,5 +54,25 @@ class DraggableView: UIView {
             // no op
             break
         }
+    }
+    
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        if let floatingHeaderView = floatingHeaderView {
+            // If the floating header view accepts this touch, then return true.
+            if floatingHeaderView.point(inside: convert(point, to: floatingHeaderView), with: event) {
+                return true
+            }
+            // Some areas of the floating header view may want to be pass-through.
+            // That is, some touches may want to be handled by the BackViewController.
+            // In this case, the view will return "false" for point(inside:).
+            // If we return "false", however, then our own gestures (e.g. pan) will not work.
+            // So, let's check by hand to see if the point is inside the floating header view.
+            // If it is, then return false.
+            if point.x > 0 && point.x < floatingHeaderView.bounds.width && point.y > 0 && point.y < floatingHeaderView.bounds.height {
+                return false
+            }
+        }
+        // The default path; return true.
+        return true
     }
 }

--- a/PanelViewController/Framework source/DraggableView.swift
+++ b/PanelViewController/Framework source/DraggableView.swift
@@ -21,6 +21,7 @@ class DraggableView: UIView {
             oldValue?.removeFromSuperview()
             if let newValue = floatingHeaderView {
                 addSubview(newValue)
+                sendSubview(toBack: newValue)
             }
         }
     }

--- a/PanelViewController/Framework source/DraggableView.swift
+++ b/PanelViewController/Framework source/DraggableView.swift
@@ -11,6 +11,13 @@ import UIKit
 protocol DraggableViewDelegate: class {
     func draggingBegan(view: DraggableView)
     func draggingEnded(view: DraggableView, velocity: CGPoint)
+    
+    /// Informs the DraggableView whether a drag should proceed.
+    ///
+    /// This is useful if you want to enforce boundaries beyond which no dragging can occur.
+    ///
+    /// - Parameter view: The DraggableView instance
+    /// - Parameter location: The current location of the drag point, in the DraggableView's coordinate system (use `convert(_, to: yourView)` to match this point to your view's coordinate system)
     func shouldDrag(view: DraggableView, location: CGPoint) -> Bool
 }
 

--- a/PanelViewController/Framework source/PaneBehavior.swift
+++ b/PanelViewController/Framework source/PaneBehavior.swift
@@ -18,7 +18,7 @@ final class PaneBehavior: UIDynamicBehavior {
     var velocity = CGPoint.zero {
         didSet {
             let current = itemBehavior.linearVelocity(for: item)
-            let delta = CGPoint(x: velocity.x - current.x, y: velocity.y - current.y)
+            let delta = CGPoint(x: 0, y: velocity.y - current.y)
             itemBehavior.addLinearVelocity(delta, for: item)
         }
     }
@@ -31,7 +31,7 @@ final class PaneBehavior: UIDynamicBehavior {
         self.item = item
         
         let attachmentBehavior = UIAttachmentBehavior(item: item, attachedToAnchor: CGPoint.zero)
-        attachmentBehavior.damping = 0.4
+        attachmentBehavior.damping = 0.7
         attachmentBehavior.frequency = 3.5
         attachmentBehavior.length = 0
         self.attachmentBehavior = attachmentBehavior

--- a/PanelViewController/Framework source/PaneBehavior.swift
+++ b/PanelViewController/Framework source/PaneBehavior.swift
@@ -31,7 +31,7 @@ final class PaneBehavior: UIDynamicBehavior {
         self.item = item
         
         let attachmentBehavior = UIAttachmentBehavior(item: item, attachedToAnchor: CGPoint.zero)
-        attachmentBehavior.damping = 0.7
+        attachmentBehavior.damping = 0.6
         attachmentBehavior.frequency = 3.5
         attachmentBehavior.length = 0
         self.attachmentBehavior = attachmentBehavior

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -117,6 +117,8 @@ class PanelViewController: UIViewController {
     deinit {
         backViewController?.leaveParentViewController()
         slidingViewController?.leaveParentViewController()
+        
+        removeObserver(self, forKeyPath: #keyPath(paneView.center))
     }
     
     override func viewDidLoad() {

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -8,27 +8,90 @@
 
 import UIKit
 
+/**
+ The three possible states of the panel that contains the sliding view controller.
+ */
 enum PanelState {
     case closed, mid, open
 }
 
+/**
+ A UIViewController that contains a back view controller, and a sliding view controller.
+ 
+ The sliding view controller is on a panel that can be dragged up and down, over the back view controller.
+ 
+ You can instantiate this directly, or subclass; either via code or on a storyboard.
+ */
 class PanelViewController: UIViewController {
     
     // MARK: - Public Properties
     
+    /**
+     The height of the panel when it is closed.
+     
+     Increasing this value will increase the height of the drag area.
+     
+     The default value is `60`.
+     */
     @IBInspectable var closedHeight: CGFloat = PanelViewController.defaultClosedHeight
+    
+    /**
+     The distance between the bottom of the drag area and the bottom of the view.
+     
+     Increasing this value will show a portion of the sliding view controller when the panel state is `.closed`.
+     
+     The default value is `0`.
+     */
     @IBInspectable var closedBottomMargin: CGFloat = PanelViewController.defaultClosedBottomMargin
     
+    /**
+     If you have defined a `floatingHeaderView`, this property will determine the minimum `Y` for this view.
+     
+     The floating header view will move with the panel, but it will not move to a `Y` position that is less than this property.
+     
+     This is useful if you want a button to appear over the drag area, but you want it to be hidden based on the panel's height.
+     
+     If this value is `nil`, then half the view's height is used.
+     
+     The default value is `nil`.
+     */
     var floatingHeaderMinY: CGFloat?
     
+    /**
+     This view will be shown above the drag area, and will move with it.
+     
+     Its origin will be adjusted, and its width. Its height will be preserved, so make sure to set the desired height yourself.
+     
+     It can function as a "pass-through" view for touches: Override `point(inside: with:)`, returning `false` for the areas you wish to pass through.
+     
+     If this value is `nil`, then no floating header will be displayed.
+     
+     The default value is `nil`.
+     */
     var floatingHeaderView: UIView? {
         get { return paneView.floatingHeaderView }
         set { paneView.floatingHeaderView = newValue }
     }
     
+    /**
+     The distance between the panel and the top of the view when the panel state equals `.mid`.
+     
+     If this value is `nil`, then half the view's height is used.
+     
+     The default value is `nil`.
+     */
     var midTopMargin: CGFloat?
+    
+    /**
+     The distance between the panel and the top of the view when the panel state equals `.open`.
+     
+     The default value is `90`.
+     */
 	@IBInspectable var openTopMargin: CGFloat = PanelViewController.defaultOpenTopMargin
     
+    /**
+     The background color of the panel's drag area.
+     */
     var panelBackgroundColor: UIColor? {
         get { return paneView.backgroundColor }
         set {
@@ -37,12 +100,24 @@ class PanelViewController: UIViewController {
         }
     }
     
+    /**
+     The background color of the panel's drag area handle.
+     */
     var panelHandleColor: UIColor? {
         get { return dragHandleView.handleColor }
         set { dragHandleView.handleColor = newValue }
     }
     
+    /**
+     If `true`, there are three possible states for the panel: open, closed, and mid.
+     
+     If `false`, the panel is either open or closed.
+     */
     @IBInspectable var showsMidState: Bool = true
+    
+    /**
+     The intitial panel state. The default is `.closed`.
+     */
     var startingState: PanelState = .closed
 
     // MARK: - Public Static Properties
@@ -222,6 +297,11 @@ class PanelViewController: UIViewController {
     
     // MARK: - Public Methods
     
+    /**
+     Animates the pane to the specified state.
+     
+     - Parameter to: The desired state
+     */
     func changeState(to newState: PanelState) {
         if newState == .mid && !showsMidState {
             return

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -138,8 +138,8 @@ class PanelViewController: UIViewController {
     private var isFirstLayout = true
     private lazy var paneBehavior = { PaneBehavior(item: paneView) }()
     private(set) var paneState: PanelState = .closed
-    private var previousPaneState: PanelState = .closed
     @objc private let paneView = DraggableView()
+    private var previousPaneState: PanelState = .closed
     private(set) var slidingViewController: UIViewController?
     @IBInspectable private var slidingViewControllerStoryBoardID : String?
     private var stretchAllowance: CGFloat { return (view.bounds.height - openTopMargin) + closedHeight }

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -117,8 +117,6 @@ class PanelViewController: UIViewController {
     deinit {
         backViewController?.leaveParentViewController()
         slidingViewController?.leaveParentViewController()
-        
-        removeObserver(self, forKeyPath: #keyPath(paneView.center))
     }
     
     override func viewDidLoad() {
@@ -150,8 +148,6 @@ class PanelViewController: UIViewController {
         adoptChildViewController(slidingViewController!, targetView: paneView)
         
         view.bringSubview(toFront: paneView)
-        
-        addObserver(self, forKeyPath: #keyPath(paneView.center), options: [.new], context: nil)
     }
     
     // MARK: - Layout
@@ -197,7 +193,7 @@ class PanelViewController: UIViewController {
         if isDragging {
             slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + offset, width: paneView.bounds.width, height: viewSize.height - closedHeight)
         } else {
-            slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + offset, width: paneView.bounds.width, height: viewSize.height - closedHeight - paneY)
+            slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + offset, width: paneView.bounds.width, height: viewSize.height - closedHeight - paneY - offset)
         }
 
         paneView.frame = CGRect(x: 0, y: paneView.frame.origin.y, width: paneView.frame.size.width, height: paneView.frame.size.height)
@@ -224,18 +220,6 @@ class PanelViewController: UIViewController {
         performStateChange(velocity: velocity)
     }
     
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-        guard
-            keyPath == #keyPath(paneView.center)
-        else {
-            return
-        }
-        
-        if !isFirstLayout {
-            view.layoutIfNeeded()
-        }
-    }
-
     // MARK: - Public Methods
     
     func changeState(to newState: PanelState) {
@@ -361,5 +345,13 @@ extension PanelViewController: DraggableViewDelegate {
     func draggingEnded(view: DraggableView, velocity: CGPoint) {
         isDragging = false
         performStateChange(velocity: velocity)
+    }
+    
+    func shouldDrag(view: DraggableView, location: CGPoint) -> Bool {
+        let thisLocation = view.convert(location, to: self.view)
+        if thisLocation.y < openTopMargin {
+            return false
+        }
+        return true
     }
 }

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -43,18 +43,18 @@ class PanelViewController: UIViewController {
     // MARK: - Private Properties
     
     private lazy var animator = { UIDynamicAnimator(referenceView: view) }()
+    private(set) var backViewController: UIViewController?
+    @IBInspectable private var backViewControllerStoryBoardID : String?
     private let dragHandleView = DragHandleView()
     private var isAnimating = false
     fileprivate var isDragging = false
     private var isFirstLayout = true
-    private(set) var backViewController: UIViewController?
     private lazy var paneBehavior = { PaneBehavior(item: paneView) }()
-    private(set) var slidingViewController: UIViewController?
     private(set) var paneState: PaneState = .closed
     private var previousPaneState: PaneState = .closed
     private let paneView = DraggableView()
-    @IBInspectable private var  mainViewControllerStoryBoardID : String?
-    @IBInspectable private var  panelViewControllerStoryBoardID : String?
+    private(set) var slidingViewController: UIViewController?
+    @IBInspectable private var slidingViewControllerStoryBoardID : String?
     private var stretchAllowance: CGFloat { return (view.bounds.height - openTopMargin) + closedHeight }
 
     private var targetPoint: CGPoint {
@@ -90,11 +90,11 @@ class PanelViewController: UIViewController {
     override func awakeFromNib() {
         super.awakeFromNib()
         
-        guard let mainVCID = self.mainViewControllerStoryBoardID else {
+        guard let mainVCID = self.backViewControllerStoryBoardID else {
             fatalError("Main View Controller ID not specified in Properties Inspector")
         }
         
-        guard let panelVCID = self.panelViewControllerStoryBoardID else {
+        guard let panelVCID = self.slidingViewControllerStoryBoardID else {
             fatalError("Panel View Controller ID not specified in Properties Inspector")
         }
         

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -180,9 +180,7 @@ class PanelViewController: UIViewController {
         
         backViewController?.view.frame = view.bounds
         
-        let offset: CGFloat
-        offset = floatingHeaderHeight
-        
+        let offset: CGFloat = floatingHeaderHeight
         dragHandleView.frame = CGRect(x: 0, y: offset, width: paneView.bounds.width, height: closedHeight + offset)
         
         if let floatingHeaderView = floatingHeaderView {
@@ -255,6 +253,22 @@ class PanelViewController: UIViewController {
         var paneFrame = paneView.frame
         paneFrame.size.height = view.bounds.height + 88
         paneView.frame = paneFrame
+        
+        if let floatingHeaderView = floatingHeaderView {
+            let frame = CGRect(x: 0, y: 0, width: paneView.bounds.width, height: floatingHeaderHeight)
+            let targetY = targetPoint.y - (paneView.bounds.height / 2)
+            
+            let floatTargetY: CGFloat
+            if targetY < floatingHeaderMinY {
+                floatTargetY = floatingHeaderMinY
+            } else {
+                floatTargetY = 0
+            }
+            
+            UIView.animate(withDuration: 0.33, animations: {
+                floatingHeaderView.frame = CGRect(x: frame.origin.x, y: floatTargetY, width: frame.size.width, height: self.floatingHeaderHeight)
+            })
+        }
         
         slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + floatingHeaderHeight, width: paneView.bounds.width, height: view.bounds.height - closedHeight - floatingHeaderHeight)
         
@@ -340,7 +354,7 @@ extension PanelViewController: DraggableViewDelegate {
         animator.removeAllBehaviors()
         isDragging = true
         
-        slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight, width: paneView.bounds.width, height: view.bounds.height - closedHeight)
+        slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + floatingHeaderHeight, width: paneView.bounds.width, height: view.bounds.height - closedHeight)
     }
     
     func draggingEnded(view: DraggableView, velocity: CGPoint) {

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -20,12 +20,8 @@ class PanelViewController: UIViewController {
     @IBInspectable var closedBottomMargin: CGFloat = PanelViewController.defaultClosedBottomMargin
     
     var floatingHeaderView: UIView? {
-        didSet {
-            oldValue?.removeFromSuperview()
-            if let newValue = floatingHeaderView {
-                paneView.addSubview(newValue)
-            }
-        }
+        get { return paneView.floatingHeaderView }
+        set { paneView.floatingHeaderView = newValue }
     }
     
     var midTopMargin: CGFloat?

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-enum PaneState {
+enum PanelState {
     case closed, mid, open
 }
 
@@ -43,7 +43,7 @@ class PanelViewController: UIViewController {
     }
     
     @IBInspectable var showsMidState: Bool = true
-    var startingState: PaneState = .closed
+    var startingState: PanelState = .closed
 
     // MARK: - Public Static Properties
     
@@ -62,8 +62,8 @@ class PanelViewController: UIViewController {
     fileprivate var isDragging = false
     private var isFirstLayout = true
     private lazy var paneBehavior = { PaneBehavior(item: paneView) }()
-    private(set) var paneState: PaneState = .closed
-    private var previousPaneState: PaneState = .closed
+    private(set) var paneState: PanelState = .closed
+    private var previousPaneState: PanelState = .closed
     @objc private let paneView = DraggableView()
     private(set) var slidingViewController: UIViewController?
     @IBInspectable private var slidingViewControllerStoryBoardID : String?
@@ -238,7 +238,7 @@ class PanelViewController: UIViewController {
 
     // MARK: - Public Methods
     
-    func changeState(to newState: PaneState) {
+    func changeState(to newState: PanelState) {
         if newState == .mid && !showsMidState {
             return
         }
@@ -355,7 +355,6 @@ extension PanelViewController: DraggableViewDelegate {
     func draggingBegan(view: DraggableView) {
         animator.removeAllBehaviors()
         isDragging = true
-        
         slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + floatingHeaderHeight, width: paneView.bounds.width, height: view.bounds.height - closedHeight)
     }
     

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -19,13 +19,11 @@ class PanelViewController: UIViewController {
     @IBInspectable var closedHeight: CGFloat = PanelViewController.defaultClosedHeight
     @IBInspectable var closedBottomMargin: CGFloat = PanelViewController.defaultClosedBottomMargin
     
-    var floatingHeaderMinY: CGFloat { return view.bounds.height / 2 }
+    var floatingHeaderMinY: CGFloat?
     
     var floatingHeaderView: UIView? {
         get { return paneView.floatingHeaderView }
-        set {
-            paneView.floatingHeaderView = newValue
-        }
+        set { paneView.floatingHeaderView = newValue }
     }
     
     var midTopMargin: CGFloat?
@@ -184,6 +182,7 @@ class PanelViewController: UIViewController {
         dragHandleView.frame = CGRect(x: 0, y: offset, width: paneView.bounds.width, height: closedHeight + offset)
         
         if let floatingHeaderView = floatingHeaderView {
+            let floatingHeaderMinY = self.floatingHeaderMinY ?? view.bounds.height / 2
             let frame = CGRect(x: 0, y: 0, width: paneView.bounds.width, height: floatingHeaderHeight)
             if paneView.frame.origin.y < floatingHeaderMinY {
                 let floatOffset = floatingHeaderMinY - paneView.frame.origin.y
@@ -259,6 +258,7 @@ class PanelViewController: UIViewController {
             let targetY = targetPoint.y - (paneView.bounds.height / 2)
             
             let floatTargetY: CGFloat
+            let floatingHeaderMinY = self.floatingHeaderMinY ?? view.bounds.height / 2
             if targetY < floatingHeaderMinY {
                 floatTargetY = floatingHeaderMinY
             } else {

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -185,6 +185,8 @@ class PanelViewController: UIViewController {
         dragHandleView.frame = CGRect(x: 0, y: floatingHeaderHeight, width: paneView.frame.size.width, height: closedHeight + floatingHeaderHeight)
         
         floatingHeaderView?.frame = CGRect(x: 0, y: 0, width: paneView.bounds.width, height: floatingHeaderHeight)
+        
+        paneView.frame = CGRect(x: 0, y: paneView.frame.origin.y, width: paneView.frame.size.width, height: paneView.frame.size.height)
     }
     
     // MARK: - Handlers

--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -19,6 +19,8 @@ class PanelViewController: UIViewController {
     @IBInspectable var closedHeight: CGFloat = PanelViewController.defaultClosedHeight
     @IBInspectable var closedBottomMargin: CGFloat = PanelViewController.defaultClosedBottomMargin
     
+    var floatingHeaderMinY: CGFloat?
+    
     var floatingHeaderView: UIView? {
         get { return paneView.floatingHeaderView }
         set { paneView.floatingHeaderView = newValue }
@@ -172,14 +174,17 @@ class PanelViewController: UIViewController {
         }
         
         backViewController?.view.frame = view.bounds
+        
+        let offset: CGFloat
+        offset = floatingHeaderHeight
+        
         if isDragging {
-            slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + floatingHeaderHeight, width: paneView.bounds.width, height: viewSize.height - closedHeight)
+            slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + offset, width: paneView.bounds.width, height: viewSize.height - closedHeight)
         } else {
-            slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + floatingHeaderHeight, width: paneView.bounds.width, height: viewSize.height - closedHeight - paneY)
+            slidingViewController?.view.frame = CGRect(x: 0, y: closedHeight + offset, width: paneView.bounds.width, height: viewSize.height - closedHeight - paneY)
         }
 
-        dragHandleView.frame = CGRect(x: 0, y: floatingHeaderHeight, width: paneView.frame.size.width, height: closedHeight + floatingHeaderHeight)
-        
+        dragHandleView.frame = CGRect(x: 0, y: offset, width: paneView.frame.size.width, height: closedHeight + offset)
         floatingHeaderView?.frame = CGRect(x: 0, y: 0, width: paneView.bounds.width, height: floatingHeaderHeight)
         
         paneView.frame = CGRect(x: 0, y: paneView.frame.origin.y, width: paneView.frame.size.width, height: paneView.frame.size.height)

--- a/PanelViewController/ViewController.swift
+++ b/PanelViewController/ViewController.swift
@@ -159,6 +159,14 @@ final class ViewController: UIViewController {
         }
         
         let headerView = ButtonContainerView()
+        headerView.buttonAction = {
+            let alertVC = UIAlertController(title: "Button", message: "The button was tapped", preferredStyle: .alert)
+            let action = UIAlertAction(title: "Ok", style: .default) { (action) in
+                alertVC.dismiss(animated: true, completion: nil)
+            }
+            alertVC.addAction(action)
+            self.present(alertVC, animated: true, completion: nil)
+        }
         headerView.frame = CGRect(x: 0, y: 0, width: 0, height: 60)
         vc.floatingHeaderView = headerView
     }

--- a/PanelViewController/ViewController.swift
+++ b/PanelViewController/ViewController.swift
@@ -167,6 +167,7 @@ final class ViewController: UIViewController {
             alertVC.addAction(action)
             self.present(alertVC, animated: true, completion: nil)
         }
+        // PanelViewController will adjust the origin and width as it sees fit. It will preserve whatever height you set.
         headerView.frame = CGRect(x: 0, y: 0, width: 0, height: 60)
         vc.floatingHeaderView = headerView
     }

--- a/PanelViewController/ViewController.swift
+++ b/PanelViewController/ViewController.swift
@@ -157,6 +157,10 @@ final class ViewController: UIViewController {
         default:
             break
         }
+        
+        let headerView = ButtonContainerView()
+        headerView.frame = CGRect(x: 0, y: 0, width: 0, height: 60)
+        vc.floatingHeaderView = headerView
     }
 }
 


### PR DESCRIPTION
Added two new properties to enable the floating header view functionality:
1. `floatingHeaderMinY`
2. `floatingHeaderView`

Please see the test project, and the documenting comments, for how to use these properties.

Also:
* Enforce a minimum Y when dragging, to match Apple Maps behavior
* Added documenting comments for the public properties and methods
* Made the panel animation less bouncy, and got rid of the wobbliness
* Renamed `PaneState` enum to `PanelState`
* Renamed the `IBInspectable` properties to match the new child VC names ("back" and "sliding")
