### PR TITLE
Changed tap to always be negative, i.e. up

### DIFF
--- a/PanelViewController/Framework source/PanelViewController.swift
+++ b/PanelViewController/Framework source/PanelViewController.swift
@@ -299,7 +299,9 @@ class PanelViewController: UIViewController {
         
         let velocity: CGPoint
         if showsMidState {
-            velocity = calculateVelocity()
+            // If it shows the mid-state always returning a negative number
+            // tells the function to always go "up" to the next state, as if it's an up swipe
+            velocity = CGPoint(x: 0, y: -1)
         } else {
             velocity = paneBehavior.velocity
         }


### PR DESCRIPTION
Simple change to make sure on tap the panel only goes up.
However, only for case where there's a mid-state.  
If there's no mid-state, the panel will go up and down on tap, from closed to open.